### PR TITLE
Change: rename owner and project UUIDs to IDs

### DIFF
--- a/src/rest_api_tests/misaki/project/project_create_test.cpp
+++ b/src/rest_api_tests/misaki/project/project_create_test.cpp
@@ -42,6 +42,7 @@ ProjectCreateTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
     // create new user
     std::string result;
     if(Kitsunemimi::Hanami::createProject(result,
+                                          inputData.get("project_id").getString(),
                                           inputData.get("project_name").getString(),
                                           error) != m_expectSuccess)
     {
@@ -58,7 +59,7 @@ ProjectCreateTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
         return false;
     }
 
-    inputData.insert("project_uuid", jsonItem.get("uuid").getString(), true);
+    inputData.insert("project_id", jsonItem.get("id").getString(), true);
 
     return true;
 }

--- a/src/rest_api_tests/misaki/project/project_delete_test.cpp
+++ b/src/rest_api_tests/misaki/project/project_delete_test.cpp
@@ -55,7 +55,7 @@ ProjectDeleteTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
     else
     {
         if(Kitsunemimi::Hanami::deleteProject(result,
-                                              inputData.get("project_name").getString(),
+                                              inputData.get("project_id").getString(),
                                               error) != m_expectSuccess)
         {
             return false;

--- a/src/rest_api_tests/misaki/project/project_get_test.cpp
+++ b/src/rest_api_tests/misaki/project/project_get_test.cpp
@@ -42,7 +42,7 @@ ProjectGetTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
                         Kitsunemimi::ErrorContainer &error)
 {
     if(m_name == "") {
-        m_name = inputData.get("project_name").getString();
+        m_name = inputData.get("project_id").getString();
     }
 
     // get user by name
@@ -61,7 +61,7 @@ ProjectGetTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
         return false;
     }
 
-    inputData.insert("project_uuid", jsonItem.get("uuid").getString(), true);
+    inputData.insert("project_id", jsonItem.get("id").getString(), true);
 
     return true;
 }

--- a/src/rest_api_tests/misaki/user/user_create_test.cpp
+++ b/src/rest_api_tests/misaki/user/user_create_test.cpp
@@ -42,6 +42,7 @@ UserCreateTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
     // create new user
     std::string result;
     if(Kitsunemimi::Hanami::createUser(result,
+                                       inputData.get("user_id").getString(),
                                        inputData.get("user_name").getString(),
                                        inputData.get("password").getString(),
                                        inputData.get("is_admin").getBool(),
@@ -62,7 +63,7 @@ UserCreateTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
         return false;
     }
 
-    inputData.insert("user_uuid", jsonItem.get("uuid").getString(), true);
+    inputData.insert("user_id", jsonItem.get("id").getString(), true);
 
     return true;
 }

--- a/src/rest_api_tests/misaki/user/user_delete_test.cpp
+++ b/src/rest_api_tests/misaki/user/user_delete_test.cpp
@@ -55,7 +55,7 @@ UserDeleteTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
     else
     {
         if(Kitsunemimi::Hanami::deleteUser(result,
-                                           inputData.get("user_name").getString(),
+                                           inputData.get("user_id").getString(),
                                            error) != m_expectSuccess)
         {
             return false;

--- a/src/rest_api_tests/misaki/user/user_get_test.cpp
+++ b/src/rest_api_tests/misaki/user/user_get_test.cpp
@@ -42,7 +42,7 @@ UserGetTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
                      Kitsunemimi::ErrorContainer &error)
 {
     if(m_name == "") {
-        m_name = inputData.get("user_name").getString();
+        m_name = inputData.get("user_id").getString();
     }
 
     // get user by name
@@ -61,7 +61,7 @@ UserGetTest::runTest(Kitsunemimi::Json::JsonItem &inputData,
         return false;
     }
 
-    inputData.insert("user_uuid", jsonItem.get("uuid").getString(), true);
+    inputData.insert("user_id", jsonItem.get("id").getString(), true);
 
     return true;
 }

--- a/src/rest_api_tests/rest_api_tests.cpp
+++ b/src/rest_api_tests/rest_api_tests.cpp
@@ -263,7 +263,7 @@ runRestApiTests()
                                           "        {\n"
                                           "            \"type\":\"input\",\n"
                                           "            \"number_of_nodes\": 784,\n"
-                                          "            \"name\": \"input1\",\n"
+                                          "            \"name\": \"input\",\n"
                                           "            \"out\": [\n"
                                           "                {\n"
                                           "                    \"target_segment\": \"central\",\n"
@@ -277,13 +277,13 @@ runRestApiTests()
                                           "            \"out\": [\n"
                                           "                {\n"
                                           "                    \"source_brick\": \"test_output\",\n"
-                                          "                    \"target_segment\": \"output2\"\n"
+                                          "                    \"target_segment\": \"output\"\n"
                                           "                }\n"
                                           "            ]\n"
                                           "        },\n"
                                           "        {\n"
                                           "            \"type\": \"output\",\n"
-                                          "            \"name\": \"output2\",\n"
+                                          "            \"name\": \"output\",\n"
                                           "            \"number_of_nodes\": 10\n"
                                           "        }\n"
                                           "    ]\n"
@@ -292,11 +292,13 @@ runRestApiTests()
     Kitsunemimi::Json::JsonItem inputData;
 
     // add data for the test-user to create
+    inputData.insert("user_id", "tsugumi");
     inputData.insert("user_name", "tsugumi");
     inputData.insert("password", "new password");
     inputData.insert("admin", true);
     inputData.insert("roles", "tester");
     inputData.insert("projects", "tester");
+    inputData.insert("project_id", "tester");
     inputData.insert("project_name", "tester");
 
     // add data from config


### PR DESCRIPTION
## Description

rename owner and project UUIDs to IDs

## Related Issues

- https://github.com/kitsudaiki/MisakiGuard/issues/9

## How it was tested?

- Tsugumi
